### PR TITLE
Fix Linting Regressions. Drop jQuery from GPA Calc

### DIFF
--- a/src/gpa/gpa_report.js
+++ b/src/gpa/gpa_report.js
@@ -1,5 +1,3 @@
-import html2pdf from 'html2pdf.js';
-
 const data = JSON.parse(localStorage.getItem('courseGPA'));
 
 document.getElementsByClassName('value name')[0].innerText = data.name;
@@ -10,9 +8,10 @@ document.getElementsByClassName('value student-type')[0].innerText = data.studen
 
 const summaryTable = document.getElementsByClassName('summary')[0];
 let totalCredits = 0;
+
 // right now the code in other file is such that the excluded courses are not reaching here.
 const typeCreditsMap = new Map(JSON.parse(data.typeCreditsMap));
-typeCreditsMap.forEach((type, credits) => {
+typeCreditsMap.forEach((credits, type) => {
   const row = document.createElement('tr');
   totalCredits += credits;
   row.innerHTML = `<td>${type}</td><td class="credits">${credits}</td>`;


### PR DESCRIPTION
Full Commit message:
```
Replace jQuery usage with VanillaJS API Calls.
Fix case mismatch of storage variables.
Remove import statement in gpa_report.js
Add some comments.
```

This PR fixes #25.
It also drops the usage of jQuery and replaces it with plain JS equivalents.
This should make the code more maintainable.
 
**Note:**
The commits have been made using the `--no-verify` flag.   
The `import` statement required to pass the ESLint hook causes a syntax error in `gpa_report.js`.