### PR TITLE
first captcha will be filled automatically

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,12 @@
     "manifest_version": 2,
     "name": "AIMS-Helper",
     "version": "0.1",
+    "content_scripts":[
+      {
+        "matches":["https://aims.iith.ac.in/aims/"],
+        "js":["/src/captcha/captcha_filler_1.js"]
+      }
+    ],
     "background": {
       "scripts": ["/src/bg/background.js"],
       "persistent":false

--- a/src/captcha/captcha_filler_1.js
+++ b/src/captcha/captcha_filler_1.js
@@ -1,0 +1,3 @@
+str = document.getElementById("appCaptchaLoginImg").src;
+captcha = str.slice(str.length-5);
+document.getElementById("captcha").value = captcha;


### PR DESCRIPTION
closes #35 
For the gif included in the issue, I've used the extension with this update.
The extension won't work on  https://aims.iith.ac.in/aims/login/loginHome which appears once a user either logs out of their current session and is taken to the given url, or the session fails to load for some reason.
The reason being /login/loginHome is also intermediate page (one with the second captcha)